### PR TITLE
Moves nbformat and nbformat_minor to ymeta, changes the YNotebook eve…

### DIFF
--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -132,13 +132,19 @@ export class NotebookModel implements INotebookModel {
    * The dirty state of the document.
    */
   get dirty(): boolean {
-    return this.sharedModel.dirty;
+    return this._dirty;
   }
   set dirty(newValue: boolean) {
-    if (newValue === this.dirty) {
+    const oldValue = this._dirty;
+    if (newValue === oldValue) {
       return;
     }
-    (this.sharedModel as models.YNotebook).dirty = newValue;
+    this._dirty = newValue;
+    this.triggerStateChange({
+      name: 'dirty',
+      oldValue,
+      newValue
+    });
   }
 
   /**
@@ -418,16 +424,21 @@ close the notebook without saving it.`,
   ): void {
     if (changes.stateChange) {
       changes.stateChange.forEach(value => {
-        if (value.name === 'nbformat') {
-          this._nbformat = value.newValue;
-        }
-        if (value.name === 'nbformatMinor') {
-          this._nbformatMinor = value.newValue;
-        }
-        if (value.name !== 'dirty' || value.oldValue !== value.newValue) {
+        if (value.name !== 'dirty' || this._dirty !== value.newValue) {
+          this._dirty = value.newValue;
           this.triggerStateChange(value);
         }
       });
+    }
+
+    if (changes.nbformatChanged) {
+      const change = changes.nbformatChanged;
+      if (change.key === 'nbformat' && change.newValue !== undefined) {
+        this._nbformat = change.newValue;
+      }
+      if (change.key === 'nbformat_minor' && change.newValue !== undefined) {
+        this._nbformatMinor = change.newValue;
+      }
     }
 
     if (changes.metadataChange) {
@@ -506,6 +517,7 @@ close the notebook without saving it.`,
    */
   readonly modelDB: IModelDB;
 
+  private _dirty = false;
   private _readOnly = false;
   private _contentChanged = new Signal<this, void>(this);
   private _stateChanged = new Signal<this, IChangedArgs<any>>(this);

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -477,6 +477,11 @@ export type NotebookChange = {
     oldValue: nbformat.INotebookMetadata;
     newValue: nbformat.INotebookMetadata | undefined;
   };
+  nbformatChanged?: {
+    key: string;
+    oldValue: number | undefined;
+    newValue: number | undefined;
+  };
   contextChange?: MapChange;
   stateChange?: Array<{
     name: string;

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -224,27 +224,27 @@ export class YNotebook
       return this._ycellMapping.get(ycell) as YCellType;
     });
 
-    this.ymeta.observe(this._onMetadataChanged);
+    this.ymeta.observe(this._onMetaChanged);
     this.ystate.observe(this._onStateChanged);
   }
 
   get nbformat(): number {
-    return this.ystate.get('nbformat');
+    return this.ymeta.get('nbformat');
   }
 
   set nbformat(value: number) {
     this.transact(() => {
-      this.ystate.set('nbformat', value);
+      this.ymeta.set('nbformat', value);
     }, false);
   }
 
   get nbformat_minor(): number {
-    return this.ystate.get('nbformatMinor');
+    return this.ymeta.get('nbformat_minor');
   }
 
   set nbformat_minor(value: number) {
     this.transact(() => {
-      this.ystate.set('nbformatMinor', value);
+      this.ymeta.set('nbformat_minor', value);
     }, false);
   }
 
@@ -253,7 +253,7 @@ export class YNotebook
    */
   dispose(): void {
     this.ycells.unobserve(this._onYCellsChanged);
-    this.ymeta.unobserve(this._onMetadataChanged);
+    this.ymeta.unobserve(this._onMetaChanged);
     this.ystate.unobserve(this._onStateChanged);
   }
 
@@ -442,7 +442,7 @@ export class YNotebook
   /**
    * Handle a change to the ystate.
    */
-  private _onMetadataChanged = (event: Y.YMapEvent<any>) => {
+  private _onMetaChanged = (event: Y.YMapEvent<any>) => {
     if (event.keysChanged.has('metadata')) {
       const change = event.changes.keys.get('metadata');
       const metadataChange = {
@@ -450,6 +450,26 @@ export class YNotebook
         newValue: this.getMetadata()
       };
       this._changed.emit({ metadataChange });
+    }
+
+    if (event.keysChanged.has('nbformat')) {
+      const change = event.changes.keys.get('nbformat');
+      const nbformatChanged = {
+        key: 'nbformat',
+        oldValue: change?.oldValue ? change!.oldValue : undefined,
+        newValue: this.nbformat
+      };
+      this._changed.emit({ nbformatChanged });
+    }
+
+    if (event.keysChanged.has('nbformat_minor')) {
+      const change = event.changes.keys.get('nbformat_minor');
+      const nbformatChanged = {
+        key: 'nbformat_minor',
+        oldValue: change?.oldValue ? change!.oldValue : undefined,
+        newValue: this.nbformat_minor
+      };
+      this._changed.emit({ nbformatChanged });
     }
   };
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     notebook_shim>=0.1
     jinja2>=3.0.3
     ypy-websocket>=0.1.6
-    jupyter_ydoc>=0.1.7
+    jupyter_ydoc>=0.1.8
 
 [options.extras_require]
 docs =


### PR DESCRIPTION
Moves nbformat and nbformat_minor to ymeta.
Changes the YNotebook signal to support the new nbformat.
Adds a local dirty property to track changes in the frontend without modifying the shared dirty attribute.

## References

## Code changes

## User-facing changes

## Backwards-incompatible changes
